### PR TITLE
Changed hooks to new version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 class VersionInjectorPlugin {
     constructor(className = 'version-panel') {
@@ -22,7 +23,7 @@ class VersionInjectorPlugin {
         this.version = packageJSON.version;
 
         compiler.hooks.compilation.tap('VersionInjectorPlugin', (compilation) => {
-            compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync(
+            HtmlWebpackPlugin.getHooks(compilation).beforeEmit.tapAsync(
                 'ReactRootPlugin',
                 (data, cb) => {
                     const htmlString = data.html;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verybigthings/version-injector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Injects version to html page",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
In new version of html-webpack-plugin usage was changed. Now Injector works with new version